### PR TITLE
Process all domain data files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ datasets~=2.11.0
 evaluate~=0.4.0
 pre-commit~=2.21.0
 torch~=2.0.0
+
+tqdm~=4.65.0
 transformers~=4.28.1
 
 ujson~=5.7.0

--- a/scripts/create_uspto_pile_mix.sh
+++ b/scripts/create_uspto_pile_mix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #  This scripts creates a mix of USPTO and Pile data.
-DOMAIN_FILE_PATH="../data/pile_uspto/data_0_time1600242225_1976.jsonl.zst"
+DOMAIN_FILE_PATH="../data/pile_uspto/*.jsonl.zst"
 PILE_FILE_PATH="../data/pile_01/01.jsonl.zst"
-OUTPUT_FILE_PATH="../data/mix_uspto.json.zst"
+OUTPUT_DIR="../data/mix_uspto_all"
 
-python -c "from mdel.pile_utils import create_pile_domain_mix; create_pile_domain_mix('$DOMAIN_FILE_PATH', '$PILE_FILE_PATH', '$OUTPUT_FILE_PATH')"
+python -c "from mdel.pile_utils import create_pile_domain_mix; create_pile_domain_mix('$DOMAIN_FILE_PATH', '$PILE_FILE_PATH', '$OUTPUT_DIR')"


### PR DESCRIPTION
The main change is that the dataset mixing script can now process a list of files in a folder, as specified by a wildcard.

Also, the files can now be processed in parallel using a ProcessPool.