### PR TITLE
Conda environment

### DIFF
--- a/conda-mdel.yml
+++ b/conda-mdel.yml
@@ -1,0 +1,29 @@
+name: mdel
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+  - defaults
+dependencies:
+  - pytorch==2.0.*
+  - pytorch-cuda==11.8
+  - cuda
+  - pip
+  - git=2.35.1
+  - ninja
+  - make
+  - cxx-compiler
+  - wget
+  - git-lfs
+  - pip:
+    - accelerate~=0.18.0
+    - datasets~=2.11.0
+    - deepspeed==0.9.2
+    - evaluate~=0.4.0
+    - pre-commit~=2.21.0
+    - scikit-learn~=1.2.2
+    - tqdm~=4.65.0
+    - transformers~=4.28.1
+    - ujson~=5.7.0
+    - wandb==0.15.2
+    - zstandard~=0.21.0


### PR DESCRIPTION
Initial version of a conda environment, this is especially useful for machines that ship with minimal setups out of the box (Such as my Jupyterhub environment) and increases our ability to reproduce the exact dependency config across various different systems.

This is an alternative to the requirements.txt which is more suitable for machines that already have parts of the dependencies installed, this conda environment also takes care of pytorch, cuda itself, and the c++ compiling tools that deepspeed needs.